### PR TITLE
Release 0.0.7 - Add privileged_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 - Custom build image support
 - Support for non-GitHub sources
 
+## [0.0.7] - 2024-01-10
+
+### Added
+
+- Added support to specify `privileged_mode` for a project.
+
 ## [0.0.6] - 2023-12-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ No modules.
 | <a name="input_github_repo_branch"></a> [github\_repo\_branch](#input\_github\_repo\_branch) | The branch of the repository that will trigger the pipeline. | `string` | n/a | yes |
 | <a name="input_github_repo_url"></a> [github\_repo\_url](#input\_github\_repo\_url) | The .git URL to the source GitHub repository. | `string` | n/a | yes |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the role. | `string` | `""` | no |
+| <a name="input_privileged_mode"></a> [privileged\_mode](#input\_privileged\_mode) | Whether to enable running the Docker daemon inside a Docker container. | `bool` | `false` | no |
 | <a name="input_vpc_access_enabled"></a> [vpc\_access\_enabled](#input\_vpc\_access\_enabled) | Whether or not access to a VPC is enabled. | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of a VPC thie project will connect to. | `string` | `""` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | The IDs of the security groups for the CodeBuild project. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |

--- a/codebuild.tf
+++ b/codebuild.tf
@@ -17,7 +17,7 @@ resource "aws_codebuild_project" "main" {
     image                       = var.codebuild_image
     image_pull_credentials_type = var.codebuild_image_pull_credentials_type
 
-    privileged_mode = true
+    privileged_mode = var.privileged_mode
 
     dynamic "environment_variable" {
       for_each = var.environment_variables

--- a/variables.tf
+++ b/variables.tf
@@ -137,3 +137,9 @@ variable "codebuild_service_role_arn" {
   description = "The service role arn the codebuild will use. If not provided, a new IAM role will be created for the codebuild."
   default     = ""
 }
+
+variable "privileged_mode" {
+  type        = bool
+  description = "Whether to enable running the Docker daemon inside a Docker container."
+  default     = false
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Add the ability to specify `privileged_mode` for the CodeBuild project.

## Why is this PR being done?
Previously this was set to `true` without the option to adjust it.

## Checklist - These are **not** mandatory

- [x] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [ ] I have deployed this change in another project successfully.

## Optional: Additional Notes
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project#privileged_mode